### PR TITLE
Fix issue: Change `char* mobile[PATH_MAX];` to `char mobile[PATH_MAX];`"

### DIFF
--- a/main.m
+++ b/main.m
@@ -284,7 +284,7 @@ void detect_jailbroken_apps()
     
     for(int i=0; i<sizeof(paths)/sizeof(paths[0]); i++) {
         for(int j=0; j<sizeof(appids)/sizeof(appids[0]); j++) {
-            char* mobile[PATH_MAX];
+            char mobile[PATH_MAX];
             snprintf(mobile,sizeof(mobile),"/var/mobile/%s/%s%s%s", paths[i][1], appids[j], paths[i][0], paths[i][2]);
             if(access(mobile, F_OK)==0) {
                 LOG("jailbroken app found %s\n", mobile);


### PR DESCRIPTION
### Description
First, I want to say that this is a fantastic project!

This PR addresses an issue with the declaration of the `mobile` array. The original declaration was `char* mobile[PATH_MAX];`, which defines an array of `char*` pointers. This was incorrect for the intended use case. 

The corrected declaration is `char mobile[PATH_MAX];`, which defines a single array of characters with a size of `PATH_MAX`.

### Changes Made
- Changed the declaration of `mobile` from `char* mobile[PATH_MAX];` to `char mobile[PATH_MAX];`.

### Reason for Change
The original declaration did not cause any immediate errors, making it a subtle and hard-to-detect issue. By changing it to a single array of characters, the code now correctly handles the `mobile` variable as intended.